### PR TITLE
chore: change pr-agent

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,16 +1,17 @@
 name: PR Agent
 on:
   pull_request:
-    types: ready_for_review
+    types:
+      - ready_for_review
+      - opened
   issue_comment:
-    types: [created, edited]
+    types:
+      - created
+      - edited
+
 jobs:
-  condition_check:
-    if: github.event.pull_request.draft == true
-      run: exit 0
-    
   pr_agent_job:
-    if: ${{ github.event.sender.type != 'Bot' }}
+    if: ${{github.event.sender.type != 'Bot' && github.event.pull_request.draft == false}}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -24,12 +25,11 @@ jobs:
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTION.AUTO_REVIEW: "true"
-          GITHUB_ACTION.AUTO_DESCRIBE: "true"
-          GITHUB_ACTION.AUTO_IMPROVE: "false"
-          PR_REVIEWER.EXTRA_INSTRUCTIONS: "必ず日本語で回答してください"
-          PR_DESCRIPTION.PUBLISH_LABELS: "false"
-          PR_DESCRIPTION.PUBLISH_DESCRIPTION_AS_COMMENT: "true"
-          PR_DESCRIPTION.KEEP_ORIGINAL_USER_TITLE: "true"
-          PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: "true"
-          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: "Please use Japanese in descriptions. Titles should have prefix of commitlint pattern such as `feat:`, `chore:`, `test:`, `fix:`, `ci:`, `docs:` etc"
+          GITHUB_ACTION.AUTO_REVIEW: 'true'
+          GITHUB_ACTION.AUTO_DESCRIBE: 'true'
+          GITHUB_ACTION.AUTO_IMPROVE: 'false'
+          PR_REVIEWER.EXTRA_INSTRUCTIONS: '必ず日本語で回答してください'
+          PR_DESCRIPTION.PUBLISH_LABELS: 'false'
+          PR_DESCRIPTION.PUBLISH_DESCRIPTION_AS_COMMENT: 'true'
+          PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: 'false'
+          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: 'Please use Japanese in descriptions.'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -30,6 +30,5 @@ jobs:
           GITHUB_ACTION.AUTO_IMPROVE: 'false'
           PR_REVIEWER.EXTRA_INSTRUCTIONS: '必ず日本語で回答してください'
           PR_DESCRIPTION.PUBLISH_LABELS: 'false'
-          PR_DESCRIPTION.PUBLISH_DESCRIPTION_AS_COMMENT: 'true'
           PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: 'false'
           PR_DESCRIPTION.EXTRA_INSTRUCTIONS: 'Please use Japanese in descriptions.'


### PR DESCRIPTION
### **PR Type**
configuration changes, enhancement


___

### **Description**
- `pull_request` イベントに `opened` タイプを追加し、新規プルリクエストにも対応
- `issue_comment` イベントのタイプをリスト形式に変更し、可読性を向上
- `pr_agent_job` の条件を更新し、ドラフトプルリクエストを除外
- 環境変数の値をシングルクォートで統一し、コードスタイルを統一
- `PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION` を `false` に変更し、元のユーザー説明を追加しないように設定


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>`pr-agent.yml` の設定変更と条件の改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml
<li><code>pull_request</code> イベントに <code>opened</code> タイプを追加<br> <li> <code>issue_comment</code> イベントのタイプをリスト形式に変更<br> <li> <code>pr_agent_job</code> の条件を更新し、ドラフトプルリクエストを除外<br> <li> 環境変数の値をシングルクォートで統一<br> <li> <code>PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION</code> を <code>false</code> に変更<br>


</details>
    

  </td>
  <td><a href="https://github.com/traPtitech/BOT_GPT/pull/13/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+15/-16</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

