### PR TITLE
chore: change pr-agent config

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,16 +1,17 @@
 name: PR Agent
 on:
   pull_request:
-    types: ready_for_review
+    types:
+      - ready_for_review
+      - opened
   issue_comment:
-    types: [created, edited]
+    types:
+      - created
+      - edited
+
 jobs:
-  condition_check:
-    if: github.event.pull_request.draft == true
-      run: exit 0
-    
   pr_agent_job:
-    if: ${{ github.event.sender.type != 'Bot' }}
+    if: ${{github.event.sender.type != 'Bot' && github.event.pull_request.draft == false}}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -24,12 +25,11 @@ jobs:
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTION.AUTO_REVIEW: "true"
-          GITHUB_ACTION.AUTO_DESCRIBE: "true"
-          GITHUB_ACTION.AUTO_IMPROVE: "false"
-          PR_REVIEWER.EXTRA_INSTRUCTIONS: "必ず日本語で回答してください"
-          PR_DESCRIPTION.PUBLISH_LABELS: "false"
-          PR_DESCRIPTION.PUBLISH_DESCRIPTION_AS_COMMENT: "true"
-          PR_DESCRIPTION.KEEP_ORIGINAL_USER_TITLE: "true"
-          PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: "true"
-          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: "Please use Japanese in descriptions. Titles should have prefix of commitlint pattern such as `feat:`, `chore:`, `test:`, `fix:`, `ci:`, `docs:` etc"
+          GITHUB_ACTION.AUTO_REVIEW: 'true'
+          GITHUB_ACTION.AUTO_DESCRIBE: 'true'
+          GITHUB_ACTION.AUTO_IMPROVE: 'false'
+          PR_REVIEWER.EXTRA_INSTRUCTIONS: '必ず日本語で回答してください'
+          PR_DESCRIPTION.PUBLISH_LABELS: 'false'
+          PR_DESCRIPTION.PUBLISH_DESCRIPTION_AS_COMMENT: 'true'
+          PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: 'false'
+          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: 'Please use Japanese in descriptions.'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -30,6 +30,5 @@ jobs:
           GITHUB_ACTION.AUTO_IMPROVE: 'false'
           PR_REVIEWER.EXTRA_INSTRUCTIONS: '必ず日本語で回答してください'
           PR_DESCRIPTION.PUBLISH_LABELS: 'false'
-          PR_DESCRIPTION.PUBLISH_DESCRIPTION_AS_COMMENT: 'true'
           PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: 'false'
           PR_DESCRIPTION.EXTRA_INSTRUCTIONS: 'Please use Japanese in descriptions.'


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- `pull_request` トリガーに `opened` を追加し、PRが開かれたときにもジョブが実行されるように変更
- `issue_comment` トリガーのフォーマットをリスト形式に変更
- `pr_agent_job` の実行条件に `draft == false` を追加し、ドラフトPRの場合はジョブが実行されないように変更
- 環境変数 `PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION` を `false` に設定し、元のユーザーの説明を追加しないように変更


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>PRエージェント設定の更新と条件の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml
<li><code>pull_request</code> トリガーに <code>opened</code> を追加<br> <li> <code>issue_comment</code> トリガーのフォーマットを変更<br> <li> <code>pr_agent_job</code> の条件を更新<br> <li> 環境変数の一部設定を変更<br>


</details>
    

  </td>
  <td><a href="https://github.com/traPtitech/BOT_GPT/pull/14/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+15/-16</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

