### PR TITLE
chore: change pr-agent config

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,16 +1,17 @@
 name: PR Agent
 on:
   pull_request:
-    types: ready_for_review
+    types:
+      - ready_for_review
+      - opened
   issue_comment:
-    types: [created, edited]
+    types:
+      - created
+      - edited
+
 jobs:
-  condition_check:
-    if: github.event.pull_request.draft == true
-      run: exit 0
-    
   pr_agent_job:
-    if: ${{ github.event.sender.type != 'Bot' }}
+    if: ${{github.event.sender.type != 'Bot' && github.event.pull_request.draft == false}}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -24,12 +25,11 @@ jobs:
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTION.AUTO_REVIEW: "true"
-          GITHUB_ACTION.AUTO_DESCRIBE: "true"
-          GITHUB_ACTION.AUTO_IMPROVE: "false"
-          PR_REVIEWER.EXTRA_INSTRUCTIONS: "必ず日本語で回答してください"
-          PR_DESCRIPTION.PUBLISH_LABELS: "false"
-          PR_DESCRIPTION.PUBLISH_DESCRIPTION_AS_COMMENT: "true"
-          PR_DESCRIPTION.KEEP_ORIGINAL_USER_TITLE: "true"
-          PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: "true"
-          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: "Please use Japanese in descriptions. Titles should have prefix of commitlint pattern such as `feat:`, `chore:`, `test:`, `fix:`, `ci:`, `docs:` etc"
+          GITHUB_ACTION.AUTO_REVIEW: 'true'
+          GITHUB_ACTION.AUTO_DESCRIBE: 'true'
+          GITHUB_ACTION.AUTO_IMPROVE: 'false'
+          PR_REVIEWER.EXTRA_INSTRUCTIONS: '必ず日本語で回答してください'
+          PR_DESCRIPTION.PUBLISH_LABELS: 'false'
+          PR_DESCRIPTION.PUBLISH_DESCRIPTION_AS_COMMENT: 'true'
+          PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: 'false'
+          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: 'Please use Japanese in descriptions.'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -30,6 +30,5 @@ jobs:
           GITHUB_ACTION.AUTO_IMPROVE: 'false'
           PR_REVIEWER.EXTRA_INSTRUCTIONS: '必ず日本語で回答してください'
           PR_DESCRIPTION.PUBLISH_LABELS: 'false'
-          PR_DESCRIPTION.PUBLISH_DESCRIPTION_AS_COMMENT: 'true'
           PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: 'false'
           PR_DESCRIPTION.EXTRA_INSTRUCTIONS: 'Please use Japanese in descriptions.'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -30,5 +30,5 @@ jobs:
           GITHUB_ACTION.AUTO_IMPROVE: 'false'
           PR_REVIEWER.EXTRA_INSTRUCTIONS: '必ず日本語で回答してください'
           PR_DESCRIPTION.PUBLISH_LABELS: 'false'
-          PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: 'false'
+          PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: 'true'
           PR_DESCRIPTION.EXTRA_INSTRUCTIONS: 'Please use Japanese in descriptions.'


### PR DESCRIPTION
### **User description**
これでどうだろう
#14 の上書きが解消されてる?
- 箇条書き1


___

### **PR Type**
configuration changes


___

### **Description**
- `pull_request` トリガーに `opened` を追加しました。
- `issue_comment` トリガーのフォーマットを変更しました。
- `pr_agent_job` の条件を修正し、ドラフトPRを除外しました。
- 環境変数の値をシングルクォートで囲むように変更しました。
- 不要な環境変数を削除しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>`pr-agent.yml` のトリガーと条件の修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml
<li><code>pull_request</code> トリガーに <code>opened</code> を追加<br> <li> <code>issue_comment</code> トリガーのフォーマットを変更<br> <li> <code>pr_agent_job</code> の条件を修正し、ドラフトPRを除外<br> <li> 環境変数の値をシングルクォートで囲むように変更<br> <li> 不要な環境変数を削除<br>


</details>
    

  </td>
  <td><a href="https://github.com/traPtitech/BOT_GPT/pull/15/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+15/-16</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

