### PR TITLE
GPT4.1miniを利用可能なモデルとして追加

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_PROXY_KEY }}
           OPENAI.API_BASE: 'https://llm-proxy.trap.jp'
-          CONFIG.MODEL: 'gpt-4o'
+          CONFIG.MODEL: 'gpt-4.1-mini'
           CONFIG.MODEL_TURBO: 'gpt-4o-mini'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTION.AUTO_REVIEW: 'true'

--- a/internal/handler/MessageReceived.go
+++ b/internal/handler/MessageReceived.go
@@ -82,7 +82,7 @@ func handleModelCommand(messageText, channelID string) {
 	if strings.Contains(messageText, "/model show") {
 		currentModel, err := repository.GetModelForChannel(channelID)
 		if err != nil {
-			currentModel = "gpt-4o"
+			currentModel = "gpt-4.1-mini"
 		}
 		_, err = bot.PostMessageWithErr(channelID, fmt.Sprintf("現在のモデル: %s", currentModel))
 		if err != nil {
@@ -94,7 +94,7 @@ func handleModelCommand(messageText, channelID string) {
 
 	// /model list - 利用可能なモデルを一覧表示
 	if strings.Contains(messageText, "/model list") {
-		availableModels := "利用可能なモデル:\n- gpt-4o(デフォルト)\n- gpt-4.1\n- o3\n- o4-mini"
+		availableModels := "利用可能なモデル:\n- gpt-4o\n- gpt-4.1\n- gpt-4.1-mini(デフォルト)\n- o3\n- o4-mini"
 		_, err := bot.PostMessageWithErr(channelID, availableModels)
 		if err != nil {
 			fmt.Println(err)
@@ -119,6 +119,7 @@ func handleModelCommand(messageText, channelID string) {
 		validModels := map[string]bool{
 			openai.GPT4o:  true,
 			openai.GPT4Dot1: true,
+			openai.GPT4Dot1Mini: true,
 			openai.O3:     true,
 			openai.O4Mini: true,
 		}

--- a/internal/migration/2_add_model_config.sql
+++ b/internal/migration/2_add_model_config.sql
@@ -2,7 +2,7 @@
 CREATE TABLE channel_model_config
 (
     channel_id VARCHAR(255) NOT NULL PRIMARY KEY,
-    model_name VARCHAR(100) NOT NULL DEFAULT 'gpt-4o'
+    model_name VARCHAR(100) NOT NULL DEFAULT 'gpt-4.1-mini'
 );
 
 -- +goose Down

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -162,7 +162,7 @@ func Chat(channelID, newMessageText string, imageBase64 []string) {
 	// チャンネルのモデル設定を取得
 	model, err := repository.GetModelForChannel(channelID)
 	if err != nil {
-		model = openai.GPT4o // デフォルト
+		model = openai.GPT4Dot1Mini // デフォルト
 	}
 
 	milvusURL := os.Getenv("MILVUS_API_URL")


### PR DESCRIPTION
- GPT4.1mini をマップに追加 (internal/handler/MessageReceived.go)
- YAMLファイルの内容を4.1miniのために変更
- SQLファイルの内容を4.1miniのために変更
- GPT4.1mini がデフォルトになるように変更 (internal/rag/rag.go)